### PR TITLE
Add toast with link to the block explorer

### DIFF
--- a/components/BlockExplorerLink.js
+++ b/components/BlockExplorerLink.js
@@ -1,0 +1,19 @@
+function BlockExplorerLink({ blockNumber }) {
+  return (
+    <div>
+      <p>Transaction successful 🎉</p>
+      <p>
+        Block explorer:{' '}
+        <a
+          href={`https://goerli-rollup-explorer.arbitrum.io/block/${blockNumber}/transactions`}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          click here!
+        </a>
+      </p>
+    </div>
+  )
+}
+
+export default BlockExplorerLink;

--- a/components/TxStatus.js
+++ b/components/TxStatus.js
@@ -16,7 +16,7 @@ function TxStatus({ setTxFinished, txHash, toastMethod }) {
 
     toastMethod(receipt.blockNumber);
     setTxFinished(txHash);
-  }, 5000);
+  }, 4000);
 
   return (
     <div />

--- a/components/TxStatus.js
+++ b/components/TxStatus.js
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef } from 'react';
+import { Aggregator } from 'bls-wallet-clients';
+
+import { NETWORKS } from "../constants";
+
+// This function will accept a transaction hash and will
+// fire a toast when the transaction is completed.
+function TxStatus({ setTxFinished, txHash, toastMethod }) {
+
+  useInterval(async () => {
+    const receipt = await getTransactionReceipt(txHash);
+
+    if (receipt === undefined) {
+      return;
+    }
+
+    toastMethod(receipt.blockNumber);
+    setTxFinished(txHash);
+  }, 5000);
+
+  return (
+    <div />
+  );
+}
+
+export default TxStatus;
+
+
+function useInterval(callback, delay) {
+  const savedCallback = useRef(callback);
+
+  // Remember the latest callback if it changes.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => {
+        clearInterval(id);
+      };
+    }
+    return undefined;
+  }, [callback, delay]);
+}
+
+async function getTransactionReceipt(hash) {
+  const aggregator = new Aggregator(NETWORKS.arbitrumGoerli.aggregatorUrl);
+  const bundleReceipt= await aggregator.lookupReceipt(hash);
+
+  return (
+    bundleReceipt && {
+      transactionHash: hash,
+      transactionIndex: bundleReceipt.transactionIndex,
+      blockHash: bundleReceipt.blockHash,
+      blockNumber: bundleReceipt.blockNumber,
+      logs: [],
+      cumulativeGasUsed: '0x0',
+      gasUsed: '0x0',
+      status: '0x1',
+      effectiveGasPrice: '0x0',
+    }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-reveal": "^1.2.2",
+    "react-toastify": "^9.0.8",
     "sweetalert2": "^11.4.33"
   },
   "devDependencies": {

--- a/pages/demo.js
+++ b/pages/demo.js
@@ -150,8 +150,7 @@ export default function Demo() {
     })
     const aggregator = new Aggregator(network.aggregatorUrl);
     await aggregator.add(bundle);
-    // console.log('tx hash: ', result?.hash);
-    // setPendingTxs([...pendingTxs, result?.hash]);
+
     console.log('mint tx submitted')
     pollBalance()
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,11 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
@@ -2253,6 +2258,13 @@ react-reveal@^1.2.2:
   integrity sha512-JCv3fAoU6Z+Lcd8U48bwzm4pMZ79qsedSXYwpwt6lJNtj/v5nKJYZZbw3yhaQPPgYePo3Y0NOCoYOq/jcsisuw==
   dependencies:
     prop-types "^15.5.10"
+
+react-toastify@^9.0.8:
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.0.8.tgz#3876c89fc6211a29027b3075010b5ec39ebe4f7e"
+  integrity sha512-EwM+teWt49HSHx+67qI08yLAW1zAsBxCXLCsUfxHYv1W7/R3ZLhrqKalh7j+kjgPna1h5LQMSMwns4tB4ww2yQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
- Added some logic to poll the aggregator `lookupReceipt()` function to get the block number back after a successful transaction
- Added a toast with a link to the Arbitrum block explorer

https://www.loom.com/share/c53fac987c26405b8bf94cee88b2b33a