### PR TITLE
Neutral team ordering

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -101,19 +101,9 @@ export default function Home() {
         <span style={{ height: '40px' }} />
         <div className={styles.teamMembers}>
           <TeamMember
-            name="Jacob Caban-Tomski "
+            name="Jacob Caban-Tomski"
             role="Software Developer"
             picturePath="/jacob.png"
-          />
-          <TeamMember
-            name="Kautuk Kundan"
-            role="Software Developer"
-            picturePath="/kautuk.png"
-          />
-          <TeamMember
-            name="James Zaki"
-            role="Project Lead"
-            picturePath="/james.png"
           />
           <TeamMember
             name="Blake Duncan"
@@ -121,14 +111,24 @@ export default function Home() {
             picturePath="/blake.png"
           />
           <TeamMember
+            name="John Guilding"
+            role="Software Developer"
+            picturePath="/john.png"
+          />
+          <TeamMember
+            name="Kautuk Kundan"
+            role="Software Developer"
+            picturePath="/kautuk.png"
+          />
+          <TeamMember
             name="Andrew Morris"
             role="Software Developer"
             picturePath="/andrew.png"
           />
           <TeamMember
-            name="John Guilding"
-            role="Software Developer"
-            picturePath="/john.png"
+            name="James Zaki"
+            role="Project Lead"
+            picturePath="/james.png"
           />
         </div>
         <span style={{ height: '40px' }} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,8 +7,14 @@ import Link from 'next/link'
 import FeatureCard from '../components/FeatureCard'
 import TeamMember from '../components/TeamMember'
 import Fade from 'react-reveal/Fade'
+import { useEffect, useState } from 'react'
+import { shuffled } from 'ethers/lib/utils'
 
 export default function Home() {
+  // Need to initially not shuffle to match server-side rendering
+  const [shouldShuffle, setShouldShuffle] = useState(false)
+  useEffect(() => setShouldShuffle(true), [])
+
   return (
     <>
       <Head>
@@ -100,36 +106,40 @@ export default function Home() {
         </Fade>
         <span style={{ height: '40px' }} />
         <div className={styles.teamMembers}>
-          <TeamMember
-            name="Jacob Caban-Tomski"
-            role="Software Developer"
-            picturePath="/jacob.png"
-          />
-          <TeamMember
-            name="Blake Duncan"
-            role="Software Developer"
-            picturePath="/blake.png"
-          />
-          <TeamMember
-            name="John Guilding"
-            role="Software Developer"
-            picturePath="/john.png"
-          />
-          <TeamMember
-            name="Kautuk Kundan"
-            role="Software Developer"
-            picturePath="/kautuk.png"
-          />
-          <TeamMember
-            name="Andrew Morris"
-            role="Software Developer"
-            picturePath="/andrew.png"
-          />
-          <TeamMember
-            name="James Zaki"
-            role="Project Lead"
-            picturePath="/james.png"
-          />
+          {
+            (shouldShuffle ? shuffled : echo)([
+              <TeamMember
+                name="Jacob Caban-Tomski"
+                role="Software Developer"
+                picturePath="/jacob.png"
+              />,
+              <TeamMember
+                name="Blake Duncan"
+                role="Software Developer"
+                picturePath="/blake.png"
+              />,
+              <TeamMember
+                name="John Guilding"
+                role="Software Developer"
+                picturePath="/john.png"
+              />,
+              <TeamMember
+                name="Kautuk Kundan"
+                role="Software Developer"
+                picturePath="/kautuk.png"
+              />,
+              <TeamMember
+                name="Andrew Morris"
+                role="Software Developer"
+                picturePath="/andrew.png"
+              />,
+              <TeamMember
+                name="James Zaki"
+                role="Project Lead"
+                picturePath="/james.png"
+              />,
+            ])
+          }
         </div>
         <span style={{ height: '40px' }} />
         <Link href="/demo">
@@ -153,4 +163,8 @@ export default function Home() {
       <div style={{ height: '80px' }} />
     </>
   )
+}
+
+function echo(value) {
+  return value
 }


### PR DESCRIPTION
## What is this PR doing?

Implements neutral team ordering:
1. Alphabetize by last name
2. Randomize if possible

## How can these changes be manually tested?

Load the homepage several times and note the team members appear in different orders.

## Does this PR resolve or contribute to any issues?

Resolves #4.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
