### PR TITLE
Link to txHash on Goerli block explorer

### DIFF
--- a/components/BlockExplorerLink.js
+++ b/components/BlockExplorerLink.js
@@ -1,19 +1,25 @@
-function BlockExplorerLink({ blockNumber }) {
+import { useMemo } from 'react';
+
+function BlockExplorerLink({ txHash }) {
+  const shortHash = useMemo(
+    () => `${txHash.slice(0, 6)}...${txHash.slice(-4)}`,
+    [txHash],
+  );
+
   return (
     <div>
       <p>Transaction successful 🎉</p>
       <p>
-        Block explorer:{' '}
         <a
-          href={`https://goerli-rollup-explorer.arbitrum.io/block/${blockNumber}/transactions`}
+          href={`https://goerli-rollup-explorer.arbitrum.io/tx/${txHash}`}
           target="_blank"
           rel="noreferrer noopener"
         >
-          click here!
+          {shortHash}
         </a>
       </p>
     </div>
-  )
+  );
 }
 
 export default BlockExplorerLink;

--- a/components/TxStatus.js
+++ b/components/TxStatus.js
@@ -1,21 +1,20 @@
 import React, { useEffect, useRef } from 'react';
 import { Aggregator } from 'bls-wallet-clients';
 
-import { NETWORKS } from "../constants";
+import { NETWORKS } from '../constants';
 
 // This function will accept a transaction hash and will
 // fire a toast when the transaction is completed.
-function TxStatus({ setTxFinished, txHash, toastMethod }) {
-
+function TxStatus({ setTxFinished, bundleHash, toastMethod }) {
   useInterval(async () => {
-    const receipt = await getTransactionReceipt(txHash);
+    const receipt = await getTransactionReceipt(bundleHash);
 
     if (receipt === undefined) {
       return;
     }
 
-    toastMethod(receipt.blockNumber);
-    setTxFinished(txHash);
+    toastMethod(receipt.transactionHash);
+    setTxFinished(bundleHash);
   }, 4000);
 
   return (
@@ -24,7 +23,6 @@ function TxStatus({ setTxFinished, txHash, toastMethod }) {
 }
 
 export default TxStatus;
-
 
 function useInterval(callback, delay) {
   const savedCallback = useRef(callback);
@@ -51,11 +49,11 @@ function useInterval(callback, delay) {
 
 async function getTransactionReceipt(hash) {
   const aggregator = new Aggregator(NETWORKS.arbitrumGoerli.aggregatorUrl);
-  const bundleReceipt= await aggregator.lookupReceipt(hash);
+  const bundleReceipt = await aggregator.lookupReceipt(hash);
 
   return (
     bundleReceipt && {
-      transactionHash: hash,
+      transactionHash: bundleReceipt.transactionHash,
       transactionIndex: bundleReceipt.transactionIndex,
       blockHash: bundleReceipt.blockHash,
       blockNumber: bundleReceipt.blockNumber,

--- a/pages/demo.js
+++ b/pages/demo.js
@@ -23,17 +23,17 @@ export default function Demo() {
   const [balanceChanging, setBalanceChanging] = useState(true)
   const [firstMint, setFirstMint] = useState(false)
   const [pendingTxs, setPendingTxs] = useState([]);
-  const [txBlockNumber, setTxBlockNumber] = useState('');
+  const [txHash, setTxHash] = useState('');
 
   useEffect(() => {
-    if (txBlockNumber) {
-      toast(<BlockExplorerLink blockNumber={txBlockNumber} />,
+    if (txHash) {
+      toast(<BlockExplorerLink txHash={txHash} />,
       {
         position: 'bottom-right',
       });
     }
-    setTxBlockNumber('');
-  }, [setTxBlockNumber, txBlockNumber]);
+    setTxHash('');
+  }, [setTxHash, txHash]);
 
   // Default network is Goerli
   const network = NETWORKS.arbitrumGoerli;
@@ -340,9 +340,9 @@ export default function Demo() {
       </div>
       {pendingTxs.map((tx) => (
         <TxStatus
-          toastMethod={setTxBlockNumber}
+          toastMethod={setTxHash}
           setTxFinished={removePendingTxs}
-          txHash={tx}
+          bundleHash={tx}
           key={tx}
         />
       ))}


### PR DESCRIPTION
We were previously linking to the block number in the goerli block explorer.  Since the aggregator now returns the tx hash we are able to link to the actual transaction